### PR TITLE
style: format release sources

### DIFF
--- a/src/database/database.rs
+++ b/src/database/database.rs
@@ -13,7 +13,7 @@ use super::databasetype::DatabaseType;
 
 /// Get the current environment, checking both ENV and ENVIRONMENT variables.
 /// Returns "dev" if neither is set.
-/// 
+///
 /// This allows users to use either:
 /// - `ENV=prod rustyroad ...`
 /// - `ENVIRONMENT=prod rustyroad ...`
@@ -140,9 +140,8 @@ impl Database {
                     .database(&self.name)
                     .host(&self.host)
                     .port(self.port);
-                let pool = MySqlPool::connect_with(options)
-                    .await
-                    .unwrap_or_else(|e| panic!(
+                let pool = MySqlPool::connect_with(options).await.unwrap_or_else(|e| {
+                    panic!(
                         "Failed to create MySQL connection pool.\n\n\
                         Config: rustyroad.toml [database] section\n\
                         Host: {}:{}\n\
@@ -151,18 +150,21 @@ impl Database {
                         Check that MySQL is running and credentials are correct.\n\n\
                         Original error: {}",
                         self.host, self.port, self.name, self.username, e
-                    ));
+                    )
+                });
                 Ok(DatabaseConnection::MySql(Arc::new(pool)))
             }
             DatabaseType::Sqlite => {
                 let pool = SqlitePool::connect(&format!("{}.db", self.name))
                     .await
-                    .unwrap_or_else(|e| panic!(
-                        "Could not connect to SQLite database at '{}.db'.\n\n\
+                    .unwrap_or_else(|e| {
+                        panic!(
+                            "Could not connect to SQLite database at '{}.db'.\n\n\
                         Ensure the file exists and is readable, or check permissions.\n\n\
                         Original error: {}",
-                        self.name, e
-                    ));
+                            self.name, e
+                        )
+                    });
                 Ok(DatabaseConnection::Sqlite(Arc::new(pool)))
             }
             DatabaseType::Postgres => {
@@ -192,14 +194,14 @@ impl Database {
                     .database(&self.name)
                     .host(&self.host)
                     .port(self.port);
-                let pool = PgPool::connect_with(options)
-                    .await
-                    .unwrap_or_else(|e| panic!(
+                let pool = PgPool::connect_with(options).await.unwrap_or_else(|e| {
+                    panic!(
                         "Failed to create PostgreSQL connection pool for '{}' at {}:{}.\n\n\
                         Config file: rustyroad.toml\n\n\
                         Original error: {}",
                         self.name, self.host, self.port, e
-                    ));
+                    )
+                });
 
                 Ok(DatabaseConnection::Pg(Arc::new(pool)))
             }

--- a/src/database/migrations/migrations.rs
+++ b/src/database/migrations/migrations.rs
@@ -758,8 +758,10 @@ pub async fn run_migration(
 
     let migrations_dir_path = MIGRATIONS_DIR.to_string();
     // find the folder that has the name of the migration in the migrations directory with the latest timestamp
-    let migration_dir_selected = find_migration_dir(migrations_dir_path.clone(), migration_name.clone())
-        .map_err(|e| CustomMigrationError::IoError(io::Error::new(io::ErrorKind::NotFound, e.to_string())))?;
+    let migration_dir_selected =
+        find_migration_dir(migrations_dir_path.clone(), migration_name.clone()).map_err(|e| {
+            CustomMigrationError::IoError(io::Error::new(io::ErrorKind::NotFound, e.to_string()))
+        })?;
     // Generate the path to the migrations directory at runtime
     let migration_dir = &migration_dir_selected;
     // Get migration files from the specified directory

--- a/src/database/migrations/run_all_migrations.rs
+++ b/src/database/migrations/run_all_migrations.rs
@@ -60,7 +60,12 @@ pub async fn run_all_migrations(direction: MigrationDirection) -> Result<(), Cus
 
         let (_, migration_name) = dir_name
             .split_once('-')
-            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "Invalid migration directory name format. Expected: <timestamp>-<name>"))
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "Invalid migration directory name format. Expected: <timestamp>-<name>",
+                )
+            })
             .map_err(CustomMigrationError::IoError)?;
 
         let migration_name = migration_name.to_string();

--- a/src/database/migrations/sql_migration_converter.rs
+++ b/src/database/migrations/sql_migration_converter.rs
@@ -127,10 +127,7 @@ pub fn detect_rogue_migrations() -> Vec<DetectedMigration> {
                 if let Some(ext) = path.extension() {
                     if ext == "sql" {
                         // Check if it looks like a migration file
-                        let filename = path
-                            .file_stem()
-                            .and_then(|s| s.to_str())
-                            .unwrap_or("");
+                        let filename = path.file_stem().and_then(|s| s.to_str()).unwrap_or("");
                         if looks_like_migration_name(filename) {
                             if let Ok(migration) = parse_sql_file(&path) {
                                 detected.push(migration);
@@ -326,7 +323,10 @@ fn normalize_sql(sql: &str) -> String {
 
     // Normalize whitespace
     let extra_whitespace = Regex::new(r"\s+").unwrap();
-    extra_whitespace.replace_all(&result, " ").trim().to_string()
+    extra_whitespace
+        .replace_all(&result, " ")
+        .trim()
+        .to_string()
 }
 
 /// Parse a single SQL statement into an operation
@@ -408,11 +408,7 @@ fn parse_alter_table(stmt: &str) -> Option<SqlOperation> {
 
     // Pattern: ALTER TABLE table_name ADD [COLUMN] column_name ...
     let table_pattern = Regex::new(r#"(?i)ALTER\s+TABLE\s+[`"\[]?(\w+)[`"\]]?"#).unwrap();
-    let table_name = table_pattern
-        .captures(stmt)?
-        .get(1)?
-        .as_str()
-        .to_string();
+    let table_name = table_pattern.captures(stmt)?.get(1)?.as_str().to_string();
 
     if stmt_upper.contains("ADD COLUMN") || stmt_upper.contains("ADD ") {
         // Extract added columns
@@ -574,10 +570,7 @@ pub fn generate_down_sql(operations: &[SqlOperation]) -> String {
                     ));
                 }
             }
-            SqlOperation::CreateIndex {
-                index_name,
-                ..
-            } => {
+            SqlOperation::CreateIndex { index_name, .. } => {
                 down_statements.push(format!("DROP INDEX IF EXISTS {};", index_name));
             }
             SqlOperation::DropIndex { index_name } => {
@@ -624,7 +617,10 @@ pub fn convert_migrations(
 }
 
 /// Convert a single migration to RustyRoad format
-fn convert_single_migration(migration: &DetectedMigration, remove_source: bool) -> ConversionResult {
+fn convert_single_migration(
+    migration: &DetectedMigration,
+    remove_source: bool,
+) -> ConversionResult {
     let timestamp = Local::now().format("%Y%m%d%H%M%S");
     let folder_name = format!("{}-{}", timestamp, migration.name);
     let destination_path = PathBuf::from(MIGRATIONS_DIR).join(&folder_name);
@@ -651,7 +647,10 @@ fn convert_single_migration(migration: &DetectedMigration, remove_source: bool) 
             message: format!("Failed to create up.sql: {}", e),
         };
     }
-    if let Err(e) = write_to_file(up_sql_path.to_str().unwrap(), migration.sql_content.as_bytes()) {
+    if let Err(e) = write_to_file(
+        up_sql_path.to_str().unwrap(),
+        migration.sql_content.as_bytes(),
+    ) {
         return ConversionResult {
             source_path: migration.source_path.clone(),
             destination_path,
@@ -713,14 +712,14 @@ fn convert_single_migration(migration: &DetectedMigration, remove_source: bool) 
 }
 
 /// Main entry point: detect and convert rogue migrations
-/// 
+///
 /// This function is designed to be called at the start of migration commands
 /// to automatically fix agent-created migrations.
-/// 
+///
 /// # Arguments
 /// * `auto_convert` - If true, automatically converts without prompting
 /// * `remove_source` - If true, removes the source files after conversion
-/// 
+///
 /// # Returns
 /// Number of migrations converted
 pub fn detect_and_convert_rogue_migrations(auto_convert: bool, remove_source: bool) -> usize {
@@ -731,7 +730,10 @@ pub fn detect_and_convert_rogue_migrations(auto_convert: bool, remove_source: bo
     }
 
     println!("\n=== RustyRoad Migration Converter ===");
-    println!("Detected {} rogue migration(s) that need conversion:\n", detected.len());
+    println!(
+        "Detected {} rogue migration(s) that need conversion:\n",
+        detected.len()
+    );
 
     for (i, migration) in detected.iter().enumerate() {
         println!(
@@ -827,14 +829,17 @@ pub fn detect_and_convert_rogue_migrations(auto_convert: bool, remove_source: bo
 }
 
 /// Check for rogue migrations and print a warning if found
-/// 
+///
 /// This is a lightweight check that can be called at the start of any
 /// migration command to warn users about improperly placed migrations.
 pub fn warn_about_rogue_migrations() {
     let detected = detect_rogue_migrations();
 
     if !detected.is_empty() {
-        eprintln!("\n*** WARNING: Detected {} SQL migration(s) in non-standard locations! ***", detected.len());
+        eprintln!(
+            "\n*** WARNING: Detected {} SQL migration(s) in non-standard locations! ***",
+            detected.len()
+        );
         eprintln!("RustyRoad expects migrations in: {}/", MIGRATIONS_DIR);
         eprintln!("\nDetected files:");
         for migration in &detected {
@@ -853,7 +858,10 @@ pub fn cleanup_empty_rogue_dirs() {
             if let Ok(mut entries) = fs::read_dir(path) {
                 if entries.next().is_none() {
                     if let Err(e) = fs::remove_dir(path) {
-                        eprintln!("Warning: Could not remove empty directory {:?}: {}", path, e);
+                        eprintln!(
+                            "Warning: Could not remove empty directory {:?}: {}",
+                            path, e
+                        );
                     } else {
                         println!("Removed empty directory: {}", dir);
                     }
@@ -869,22 +877,13 @@ mod tests {
 
     #[test]
     fn test_extract_migration_name() {
-        assert_eq!(
-            extract_migration_name("20231224150552_user"),
-            "user"
-        );
+        assert_eq!(extract_migration_name("20231224150552_user"), "user");
         assert_eq!(
             extract_migration_name("20231224150552-create_users"),
             "create_users"
         );
-        assert_eq!(
-            extract_migration_name("001_create_users"),
-            "create_users"
-        );
-        assert_eq!(
-            extract_migration_name("V1__create_users"),
-            "create_users"
-        );
+        assert_eq!(extract_migration_name("001_create_users"), "create_users");
+        assert_eq!(extract_migration_name("V1__create_users"), "create_users");
         assert_eq!(
             extract_migration_name("create_users_table"),
             "create_users_table"
@@ -906,10 +905,14 @@ mod tests {
     fn test_parse_create_table() {
         let sql = "CREATE TABLE users (id SERIAL PRIMARY KEY, name VARCHAR(255) NOT NULL)";
         let ops = parse_sql_operations(sql);
-        
+
         assert_eq!(ops.len(), 1);
         match &ops[0] {
-            SqlOperation::CreateTable { table_name, columns, .. } => {
+            SqlOperation::CreateTable {
+                table_name,
+                columns,
+                ..
+            } => {
                 assert_eq!(table_name, "users");
                 assert_eq!(columns.len(), 2);
             }
@@ -921,7 +924,7 @@ mod tests {
     fn test_parse_create_table_if_not_exists() {
         let sql = "CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY)";
         let ops = parse_sql_operations(sql);
-        
+
         assert_eq!(ops.len(), 1);
         match &ops[0] {
             SqlOperation::CreateTable { table_name, .. } => {
@@ -935,10 +938,14 @@ mod tests {
     fn test_parse_alter_table_add_column() {
         let sql = "ALTER TABLE users ADD COLUMN email VARCHAR(255)";
         let ops = parse_sql_operations(sql);
-        
+
         assert_eq!(ops.len(), 1);
         match &ops[0] {
-            SqlOperation::AlterTableAddColumn { table_name, columns, .. } => {
+            SqlOperation::AlterTableAddColumn {
+                table_name,
+                columns,
+                ..
+            } => {
                 assert_eq!(table_name, "users");
                 assert!(columns.contains(&"email".to_string()));
             }
@@ -950,7 +957,7 @@ mod tests {
     fn test_parse_drop_table() {
         let sql = "DROP TABLE IF EXISTS users";
         let ops = parse_sql_operations(sql);
-        
+
         assert_eq!(ops.len(), 1);
         match &ops[0] {
             SqlOperation::DropTable { table_name } => {
@@ -964,10 +971,14 @@ mod tests {
     fn test_parse_create_index() {
         let sql = "CREATE INDEX idx_users_email ON users (email)";
         let ops = parse_sql_operations(sql);
-        
+
         assert_eq!(ops.len(), 1);
         match &ops[0] {
-            SqlOperation::CreateIndex { index_name, table_name, .. } => {
+            SqlOperation::CreateIndex {
+                index_name,
+                table_name,
+                ..
+            } => {
                 assert_eq!(index_name, "idx_users_email");
                 assert_eq!(table_name, "users");
             }
@@ -1007,7 +1018,7 @@ mod tests {
             CREATE TABLE posts (id SERIAL PRIMARY KEY, user_id INTEGER);
             CREATE INDEX idx_posts_user ON posts (user_id);
         "#;
-        
+
         let ops = parse_sql_operations(sql);
         assert_eq!(ops.len(), 3);
     }
@@ -1023,7 +1034,7 @@ mod tests {
                comment */
             CREATE TABLE posts (id INTEGER);
         "#;
-        
+
         let normalized = normalize_sql(sql);
         assert!(!normalized.contains("--"));
         assert!(!normalized.contains("/*"));

--- a/src/database/schema.rs
+++ b/src/database/schema.rs
@@ -164,7 +164,12 @@ pub async fn inspect_schema(format: &str) -> Result<(), CustomMigrationError> {
         for table in &all_tables {
             println!("Table: {}", table.name);
             for col in &table.columns {
-                println!("  - {}: {}{}", col.name, col.r#type, if col.nullable { "" } else { " NOT NULL" });
+                println!(
+                    "  - {}: {}{}",
+                    col.name,
+                    col.r#type,
+                    if col.nullable { "" } else { " NOT NULL" }
+                );
             }
             println!("{:-<30}", "");
         }
@@ -367,7 +372,8 @@ async fn execute_query_json(
             let mut rows_data: Vec<serde_json::Map<String, serde_json::Value>> = Vec::new();
 
             for row in rows {
-                let mut row_map: serde_json::Map<String, serde_json::Value> = serde_json::Map::new();
+                let mut row_map: serde_json::Map<String, serde_json::Value> =
+                    serde_json::Map::new();
                 let columns = row.columns();
                 for column in columns {
                     let col_name = column.name().to_string();
@@ -402,7 +408,8 @@ async fn execute_query_json(
             let mut rows_data: Vec<serde_json::Map<String, serde_json::Value>> = Vec::new();
 
             for row in rows {
-                let mut row_map: serde_json::Map<String, serde_json::Value> = serde_json::Map::new();
+                let mut row_map: serde_json::Map<String, serde_json::Value> =
+                    serde_json::Map::new();
                 let columns = row.columns();
                 for column in columns {
                     let col_name = column.name().to_string();
@@ -437,7 +444,8 @@ async fn execute_query_json(
             let mut rows_data: Vec<serde_json::Map<String, serde_json::Value>> = Vec::new();
 
             for row in rows {
-                let mut row_map: serde_json::Map<String, serde_json::Value> = serde_json::Map::new();
+                let mut row_map: serde_json::Map<String, serde_json::Value> =
+                    serde_json::Map::new();
                 let columns = row.columns();
                 for column in columns {
                     let col_name = column.name().to_string();

--- a/src/features/grapesjs/implementation.rs
+++ b/src/features/grapesjs/implementation.rs
@@ -140,19 +140,17 @@ To access the page builder, go to the /page/{pageId} URL. For example, if you ar
 /// let result = write_to_page_model();
 /// ```
 pub async fn write_to_page_model() -> Result<(), Error> {
-    fs::read_to_string("./rustyroad.toml")
-        .unwrap_or_else(|_| {
-            let current_dir_path = std::env::current_dir()
-                .unwrap_or_else(|_| ".".into());
-            let current_dir = current_dir_path.display();
-            panic!(
-                "Error: This is not a RustyRoad project.\n\n\
+    fs::read_to_string("./rustyroad.toml").unwrap_or_else(|_| {
+        let current_dir_path = std::env::current_dir().unwrap_or_else(|_| ".".into());
+        let current_dir = current_dir_path.display();
+        panic!(
+            "Error: This is not a RustyRoad project.\n\n\
                 Current directory: {}\n\
                 Could not find rustyroad.toml.\n\n\
                 Please run `rustyroad new` to create a new project.",
-                current_dir
-            )
-        });
+            current_dir
+        )
+    });
     let page_model_file_location = "src/models/page.rs";
 
     // create the file

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1449,71 +1449,72 @@ Example:\n\
                 if matches.subcommand_name() != Some("convert") {
                     warn_about_rogue_migrations();
                 }
-                
+
                 match matches.subcommand() {
-                Some(("generate", matches)) => {
-                    let name = matches.get_one::<String>("name").unwrap().to_string();
-                    // Get the column definitions provided via CLI
-                    let columns: Vec<String> = matches
-                        .get_many::<String>("columns")
-                        .map(|vals| vals.map(|s| s.to_string()).collect())
-                        .unwrap_or_else(Vec::new);
+                    Some(("generate", matches)) => {
+                        let name = matches.get_one::<String>("name").unwrap().to_string();
+                        // Get the column definitions provided via CLI
+                        let columns: Vec<String> = matches
+                            .get_many::<String>("columns")
+                            .map(|vals| vals.map(|s| s.to_string()).collect())
+                            .unwrap_or_else(Vec::new);
 
-                    println!("Generating migration: {}", name);
-                    // Pass the captured columns vector to the updated create_migration function
-                    create_migration(&name, columns)
-                        .await
-                        .expect("Error creating migration");
-                }
-                Some(("all", _)) => {
-                    Self::print_config_info();
-                    get_project_name_from_rustyroad_toml()
-                        .unwrap_or_else(|why| panic!("This is not a Rusty Road project: {why}"));
-
-                    run_all_migrations(MigrationDirection::Up)
-                        .await
-                        .expect("Error running migrations");
-                }
-                Some(("run", matches)) => {
-                    Self::print_config_info();
-                    let name = matches.get_one::<String>("name").unwrap().to_string();
-
-                    run_migration(name.clone(), MigrationDirection::Up)
-                        .await
-                        .expect("Error running migration");
-                    println!("'{}' migration completed successfully!", name.clone());
-                }
-                Some(("rollback", matches)) => {
-                    Self::print_config_info();
-                    let name = matches.get_one::<String>("name").unwrap().to_string();
-                    // Create a confirmation prompt
-                    let confirmation = Confirm::new()
-                        .with_prompt(format!(
-                            "Are you sure you want to rollback the '{}' migration?",
-                            name
-                        ))
-                        .interact()
-                        .map_err(|err| io::Error::other(err))
-                        .expect("Error rolling back migration: ");
-
-                    if confirmation {
-                        println!("Rolling back the '{}' migration...", name.clone());
-                        run_migration(name.clone(), MigrationDirection::Down)
+                        println!("Generating migration: {}", name);
+                        // Pass the captured columns vector to the updated create_migration function
+                        create_migration(&name, columns)
                             .await
-                            .expect("Error rolling back migration");
-                        println!(
-                            "'{}' migration rollback completed successfully!",
-                            name.clone()
-                        );
-                    } else {
-                        println!("'{}' migration rollback canceled by user.", name);
+                            .expect("Error creating migration");
                     }
-                }
-                Some(("redo", matches)) => {
-                    Self::print_config_info();
-                    let name = matches.get_one::<String>("name").unwrap().to_string();
+                    Some(("all", _)) => {
+                        Self::print_config_info();
+                        get_project_name_from_rustyroad_toml().unwrap_or_else(|why| {
+                            panic!("This is not a Rusty Road project: {why}")
+                        });
 
-                    let confirmation = Confirm::new()
+                        run_all_migrations(MigrationDirection::Up)
+                            .await
+                            .expect("Error running migrations");
+                    }
+                    Some(("run", matches)) => {
+                        Self::print_config_info();
+                        let name = matches.get_one::<String>("name").unwrap().to_string();
+
+                        run_migration(name.clone(), MigrationDirection::Up)
+                            .await
+                            .expect("Error running migration");
+                        println!("'{}' migration completed successfully!", name.clone());
+                    }
+                    Some(("rollback", matches)) => {
+                        Self::print_config_info();
+                        let name = matches.get_one::<String>("name").unwrap().to_string();
+                        // Create a confirmation prompt
+                        let confirmation = Confirm::new()
+                            .with_prompt(format!(
+                                "Are you sure you want to rollback the '{}' migration?",
+                                name
+                            ))
+                            .interact()
+                            .map_err(|err| io::Error::other(err))
+                            .expect("Error rolling back migration: ");
+
+                        if confirmation {
+                            println!("Rolling back the '{}' migration...", name.clone());
+                            run_migration(name.clone(), MigrationDirection::Down)
+                                .await
+                                .expect("Error rolling back migration");
+                            println!(
+                                "'{}' migration rollback completed successfully!",
+                                name.clone()
+                            );
+                        } else {
+                            println!("'{}' migration rollback canceled by user.", name);
+                        }
+                    }
+                    Some(("redo", matches)) => {
+                        Self::print_config_info();
+                        let name = matches.get_one::<String>("name").unwrap().to_string();
+
+                        let confirmation = Confirm::new()
                         .with_prompt(format!(
                             "Redo will rollback (down) then re-apply (up) the '{}' migration. Continue?",
                             name
@@ -1522,23 +1523,23 @@ Example:\n\
                         .map_err(|err| io::Error::other(err))
                         .expect("Error confirming redo migration: ");
 
-                    if confirmation {
-                        println!("Rolling back '{}'...", name);
-                        run_migration(name.clone(), MigrationDirection::Down)
-                            .await
-                            .expect("Error rolling back migration");
-                        println!("Re-applying '{}'...", name);
-                        run_migration(name.clone(), MigrationDirection::Up)
-                            .await
-                            .expect("Error running migration");
-                        println!("'{}' migration redo completed successfully!", name);
-                    } else {
-                        println!("'{}' migration redo canceled by user.", name);
+                        if confirmation {
+                            println!("Rolling back '{}'...", name);
+                            run_migration(name.clone(), MigrationDirection::Down)
+                                .await
+                                .expect("Error rolling back migration");
+                            println!("Re-applying '{}'...", name);
+                            run_migration(name.clone(), MigrationDirection::Up)
+                                .await
+                                .expect("Error running migration");
+                            println!("'{}' migration redo completed successfully!", name);
+                        } else {
+                            println!("'{}' migration redo canceled by user.", name);
+                        }
                     }
-                }
-                Some(("reset", _)) => {
-                    Self::print_config_info();
-                    let confirmation = Confirm::new()
+                    Some(("reset", _)) => {
+                        Self::print_config_info();
+                        let confirmation = Confirm::new()
                         .with_prompt(
                             "Reset will rollback ALL migrations (down) in reverse order. This is destructive. Continue?",
                         )
@@ -1546,79 +1547,107 @@ Example:\n\
                         .map_err(|err| io::Error::other(err))
                         .expect("Error confirming reset migrations: ");
 
-                    if confirmation {
-                        run_all_migrations(MigrationDirection::Down)
-                            .await
-                            .expect("Error rolling back migrations");
-                        println!("All migrations rolled back successfully.");
-                    } else {
-                        println!("Migration reset canceled by user.");
-                    }
-                }
-                Some(("list", _)) => {
-                    Self::print_config_info();
-                    list_migrations(format).await.expect("Error listing migrations");
-                }
-                Some(("convert", matches)) => {
-                    let remove_source = matches.get_flag("remove-source");
-                    let dry_run = matches.get_flag("dry-run");
-
-                    if dry_run {
-                        // Just detect and report, don't convert
-                        let detected = detect_rogue_migrations();
-                        if detected.is_empty() {
-                            println!("No rogue migrations detected.");
+                        if confirmation {
+                            run_all_migrations(MigrationDirection::Down)
+                                .await
+                                .expect("Error rolling back migrations");
+                            println!("All migrations rolled back successfully.");
                         } else {
-                            println!("Found {} rogue migration(s) that would be converted:\n", detected.len());
-                            for (i, migration) in detected.iter().enumerate() {
+                            println!("Migration reset canceled by user.");
+                        }
+                    }
+                    Some(("list", _)) => {
+                        Self::print_config_info();
+                        list_migrations(format)
+                            .await
+                            .expect("Error listing migrations");
+                    }
+                    Some(("convert", matches)) => {
+                        let remove_source = matches.get_flag("remove-source");
+                        let dry_run = matches.get_flag("dry-run");
+
+                        if dry_run {
+                            // Just detect and report, don't convert
+                            let detected = detect_rogue_migrations();
+                            if detected.is_empty() {
+                                println!("No rogue migrations detected.");
+                            } else {
                                 println!(
-                                    "  {}. {} (from {:?})",
-                                    i + 1,
-                                    migration.name,
-                                    migration.source_path
+                                    "Found {} rogue migration(s) that would be converted:\n",
+                                    detected.len()
                                 );
-                                println!("     Operations:");
-                                for op in &migration.operations {
-                                    match op {
-                                        SqlOperation::CreateTable { table_name, .. } => {
-                                            println!("       - CREATE TABLE {}", table_name);
-                                        }
-                                        SqlOperation::DropTable { table_name } => {
-                                            println!("       - DROP TABLE {}", table_name);
-                                        }
-                                        SqlOperation::AlterTableAddColumn { table_name, columns, .. } => {
-                                            println!("       - ALTER TABLE {} ADD COLUMN {}", table_name, columns.join(", "));
-                                        }
-                                        SqlOperation::AlterTableDropColumn { table_name, columns, .. } => {
-                                            println!("       - ALTER TABLE {} DROP COLUMN {}", table_name, columns.join(", "));
-                                        }
-                                        SqlOperation::CreateIndex { index_name, table_name, .. } => {
-                                            println!("       - CREATE INDEX {} ON {}", index_name, table_name);
-                                        }
-                                        SqlOperation::DropIndex { index_name } => {
-                                            println!("       - DROP INDEX {}", index_name);
-                                        }
-                                        SqlOperation::RawSql { .. } => {
-                                            println!("       - [Raw SQL statement]");
+                                for (i, migration) in detected.iter().enumerate() {
+                                    println!(
+                                        "  {}. {} (from {:?})",
+                                        i + 1,
+                                        migration.name,
+                                        migration.source_path
+                                    );
+                                    println!("     Operations:");
+                                    for op in &migration.operations {
+                                        match op {
+                                            SqlOperation::CreateTable { table_name, .. } => {
+                                                println!("       - CREATE TABLE {}", table_name);
+                                            }
+                                            SqlOperation::DropTable { table_name } => {
+                                                println!("       - DROP TABLE {}", table_name);
+                                            }
+                                            SqlOperation::AlterTableAddColumn {
+                                                table_name,
+                                                columns,
+                                                ..
+                                            } => {
+                                                println!(
+                                                    "       - ALTER TABLE {} ADD COLUMN {}",
+                                                    table_name,
+                                                    columns.join(", ")
+                                                );
+                                            }
+                                            SqlOperation::AlterTableDropColumn {
+                                                table_name,
+                                                columns,
+                                                ..
+                                            } => {
+                                                println!(
+                                                    "       - ALTER TABLE {} DROP COLUMN {}",
+                                                    table_name,
+                                                    columns.join(", ")
+                                                );
+                                            }
+                                            SqlOperation::CreateIndex {
+                                                index_name,
+                                                table_name,
+                                                ..
+                                            } => {
+                                                println!(
+                                                    "       - CREATE INDEX {} ON {}",
+                                                    index_name, table_name
+                                                );
+                                            }
+                                            SqlOperation::DropIndex { index_name } => {
+                                                println!("       - DROP INDEX {}", index_name);
+                                            }
+                                            SqlOperation::RawSql { .. } => {
+                                                println!("       - [Raw SQL statement]");
+                                            }
                                         }
                                     }
+                                    println!();
                                 }
-                                println!();
+                                println!("Run without --dry-run to convert these migrations.");
                             }
-                            println!("Run without --dry-run to convert these migrations.");
-                        }
-                    } else {
-                        let count = detect_and_convert_rogue_migrations(true, remove_source);
-                        if count == 0 {
-                            println!("No rogue migrations found to convert.");
+                        } else {
+                            let count = detect_and_convert_rogue_migrations(true, remove_source);
+                            if count == 0 {
+                                println!("No rogue migrations found to convert.");
+                            }
                         }
                     }
-                }
-                _ => {
-                    println!("Invalid migration choice");
+                    _ => {
+                        println!("Invalid migration choice");
+                    }
                 }
             }
-            },
             // Add Feature Case
             Some(("feature", matches)) => match matches.subcommand() {
                 Some(("add", matches)) => match matches.subcommand() {
@@ -1726,7 +1755,11 @@ Example:\n\
                 let project_name = std::fs::read_to_string("rustyroad.toml")
                     .ok()
                     .and_then(|contents| toml::from_str::<toml::Value>(&contents).ok())
-                    .and_then(|v| v.get("rustyroad_project").and_then(|t| t.as_table()).cloned())
+                    .and_then(|v| {
+                        v.get("rustyroad_project")
+                            .and_then(|t| t.as_table())
+                            .cloned()
+                    })
                     .and_then(|t| {
                         t.get("name")
                             .and_then(|name| name.as_str())
@@ -1753,7 +1786,10 @@ Example:\n\
                     println!("Database config file: {}", file_name);
 
                     println!("Database:");
-                    println!("  type: {}", db.database_type.to_string().to_ascii_lowercase());
+                    println!(
+                        "  type: {}",
+                        db.database_type.to_string().to_ascii_lowercase()
+                    );
                     println!("  host: {}", db.host);
                     println!("  port: {}", db.port);
                     println!("  name: {}", db.name);

--- a/src/mcp/main.rs
+++ b/src/mcp/main.rs
@@ -393,13 +393,11 @@ impl McpServer {
         let _guard = self.change_to_project_dir()?;
 
         match direction {
-            "status" => {
-                Ok(json!({
-                    "success": true,
-                    "message": "Use 'rustyroad migration list' to see migration status",
-                    "hint": "Migration status checking via MCP coming soon"
-                }))
-            }
+            "status" => Ok(json!({
+                "success": true,
+                "message": "Use 'rustyroad migration list' to see migration status",
+                "hint": "Migration status checking via MCP coming soon"
+            })),
             "up" => {
                 if let Some(migration_name) = name {
                     rustyroad::database::run_migration(
@@ -446,7 +444,10 @@ impl McpServer {
                     Err("Rolling back all migrations requires specifying a migration name for safety. Use 'rustyroad migration reset' CLI for full reset.".to_string())
                 }
             }
-            _ => Err(format!("Invalid direction: {}. Use 'up', 'down', or 'status'", direction)),
+            _ => Err(format!(
+                "Invalid direction: {}. Use 'up', 'down', or 'status'",
+                direction
+            )),
         }
     }
 
@@ -628,7 +629,8 @@ impl McpServer {
 
                             // Extract span information (file:line:col)
                             let mut spans: Vec<Value> = Vec::new();
-                            if let Some(spans_arr) = message.get("spans").and_then(|v| v.as_array()) {
+                            if let Some(spans_arr) = message.get("spans").and_then(|v| v.as_array())
+                            {
                                 for span in spans_arr {
                                     let file = span
                                         .get("file_name")
@@ -638,10 +640,8 @@ impl McpServer {
                                         .get("line_start")
                                         .and_then(|v| v.as_u64())
                                         .unwrap_or(0);
-                                    let line_end = span
-                                        .get("line_end")
-                                        .and_then(|v| v.as_u64())
-                                        .unwrap_or(0);
+                                    let line_end =
+                                        span.get("line_end").and_then(|v| v.as_u64()).unwrap_or(0);
                                     let col_start = span
                                         .get("column_start")
                                         .and_then(|v| v.as_u64())
@@ -764,23 +764,21 @@ impl McpServer {
         }
 
         match fs::read_to_string(&toml_path) {
-            Ok(content) => {
-                match toml::from_str::<toml::Value>(&content) {
-                    Ok(parsed) => json!({
-                        "exists": true,
-                        "content": parsed
-                    }),
-                    Err(e) => json!({
-                        "exists": true,
-                        "raw": content,
-                        "parse_error": e.to_string()
-                    })
-                }
-            }
+            Ok(content) => match toml::from_str::<toml::Value>(&content) {
+                Ok(parsed) => json!({
+                    "exists": true,
+                    "content": parsed
+                }),
+                Err(e) => json!({
+                    "exists": true,
+                    "raw": content,
+                    "parse_error": e.to_string()
+                }),
+            },
             Err(e) => json!({
                 "exists": true,
                 "error": format!("Failed to read: {}", e)
-            })
+            }),
         }
     }
 
@@ -875,7 +873,10 @@ impl McpServer {
         for dir_name in key_dirs {
             let dir_path = src_path.join(dir_name);
             if dir_path.exists() {
-                structure.insert(dir_name.to_string(), self.get_subdirectory_structure(&dir_path));
+                structure.insert(
+                    dir_name.to_string(),
+                    self.get_subdirectory_structure(&dir_path),
+                );
             }
         }
 
@@ -985,12 +986,15 @@ impl McpServer {
 
         // Regex patterns for Actix route attributes
         // Matches: #[get("/path")], #[post("/path")], etc.
-        let attr_route_re = Regex::new(r#"#\[(get|post|put|delete|patch|head|options)\("([^"]+)"\)\]"#)
-            .map_err(|e| format!("Regex error: {}", e))?;
+        let attr_route_re =
+            Regex::new(r#"#\[(get|post|put|delete|patch|head|options)\("([^"]+)"\)\]"#)
+                .map_err(|e| format!("Regex error: {}", e))?;
 
         // Matches: .route("/path", web::get().to(...))
-        let route_method_re = Regex::new(r#"\.route\(\s*"([^"]+)"\s*,\s*web::(get|post|put|delete|patch|head|options)\(\)"#)
-            .map_err(|e| format!("Regex error: {}", e))?;
+        let route_method_re = Regex::new(
+            r#"\.route\(\s*"([^"]+)"\s*,\s*web::(get|post|put|delete|patch|head|options)\(\)"#,
+        )
+        .map_err(|e| format!("Regex error: {}", e))?;
 
         // Matches: web::resource("/path").route(web::get().to(...))
         let resource_re = Regex::new(r#"web::resource\(\s*"([^"]+)"\s*\)"#)
@@ -1096,7 +1100,8 @@ impl McpServer {
     }
 
     fn change_to_project_dir(&self) -> Result<DirGuard, String> {
-        let original = env::current_dir().map_err(|e| format!("Failed to get current dir: {}", e))?;
+        let original =
+            env::current_dir().map_err(|e| format!("Failed to get current dir: {}", e))?;
         env::set_current_dir(&self.project_dir)
             .map_err(|e| format!("Failed to change to project dir: {}", e))?;
         Ok(DirGuard { original })
@@ -1136,8 +1141,9 @@ impl McpServer {
 
         // Regex patterns for parsing cargo test output
         // Match summary line: "test result: ok. X passed; Y failed; Z ignored"
-        let summary_re = Regex::new(r"test result: \w+\. (\d+) passed; (\d+) failed; (\d+) ignored")
-            .map_err(|e| format!("Failed to compile regex: {}", e))?;
+        let summary_re =
+            Regex::new(r"test result: \w+\. (\d+) passed; (\d+) failed; (\d+) ignored")
+                .map_err(|e| format!("Failed to compile regex: {}", e))?;
 
         // Match failed test names: "---- test_name stdout ----" followed by error
         let failed_test_re = Regex::new(r"---- ([^\s]+) stdout ----")
@@ -1176,7 +1182,11 @@ impl McpServer {
             }
 
             // Check for end of failure block
-            if in_failure_block && (line.starts_with("---- ") || line.starts_with("failures:") || line.starts_with("test result:")) {
+            if in_failure_block
+                && (line.starts_with("---- ")
+                    || line.starts_with("failures:")
+                    || line.starts_with("test result:"))
+            {
                 if let Some(test_name) = current_failed_test.take() {
                     failed_tests.push(json!({
                         "name": test_name,
@@ -1352,10 +1362,7 @@ impl McpServer {
     }
 
     async fn handle_recent_changes(&self, args: Value) -> Result<Value, String> {
-        let limit = args
-            .get("limit")
-            .and_then(|v| v.as_i64())
-            .unwrap_or(10) as usize;
+        let limit = args.get("limit").and_then(|v| v.as_i64()).unwrap_or(10) as usize;
 
         let _guard = self.change_to_project_dir()?;
 
@@ -1459,18 +1466,16 @@ impl McpServer {
         let id = request.id.clone().unwrap_or(Value::Null);
 
         let result = match request.method.as_str() {
-            "initialize" => {
-                Ok(json!({
-                    "protocolVersion": PROTOCOL_VERSION,
-                    "serverInfo": {
-                        "name": SERVER_NAME,
-                        "version": SERVER_VERSION
-                    },
-                    "capabilities": {
-                        "tools": {}
-                    }
-                }))
-            }
+            "initialize" => Ok(json!({
+                "protocolVersion": PROTOCOL_VERSION,
+                "serverInfo": {
+                    "name": SERVER_NAME,
+                    "version": SERVER_VERSION
+                },
+                "capabilities": {
+                    "tools": {}
+                }
+            })),
             "initialized" => Ok(json!({})),
             "tools/list" => {
                 let tools = self.get_tools();
@@ -1692,8 +1697,7 @@ fn register_with_opencode() -> Result<(), String> {
     let mut config: Value = if config_path.exists() {
         let content = fs::read_to_string(&config_path)
             .map_err(|e| format!("Failed to read config: {}", e))?;
-        serde_json::from_str(&content)
-            .map_err(|e| format!("Failed to parse config: {}", e))?
+        serde_json::from_str(&content).map_err(|e| format!("Failed to parse config: {}", e))?
     } else {
         json!({
             "$schema": "https://opencode.ai/config.json"
@@ -1701,8 +1705,8 @@ fn register_with_opencode() -> Result<(), String> {
     };
 
     // Get the path to the rustyroad-mcp binary
-    let binary_path = env::current_exe()
-        .map_err(|e| format!("Failed to get executable path: {}", e))?;
+    let binary_path =
+        env::current_exe().map_err(|e| format!("Failed to get executable path: {}", e))?;
 
     // Add/update MCP server config
     let mcp = config
@@ -1711,9 +1715,7 @@ fn register_with_opencode() -> Result<(), String> {
         .entry("mcp")
         .or_insert(json!({}));
 
-    let mcp_obj = mcp
-        .as_object_mut()
-        .ok_or("MCP config is not an object")?;
+    let mcp_obj = mcp.as_object_mut().ok_or("MCP config is not an object")?;
 
     mcp_obj.insert(
         "rustyroad".to_string(),
@@ -1733,8 +1735,7 @@ fn register_with_opencode() -> Result<(), String> {
     // Write config back
     let content = serde_json::to_string_pretty(&config)
         .map_err(|e| format!("Failed to serialize config: {}", e))?;
-    fs::write(&config_path, content)
-        .map_err(|e| format!("Failed to write config: {}", e))?;
+    fs::write(&config_path, content).map_err(|e| format!("Failed to write config: {}", e))?;
 
     println!("Registered RustyRoad MCP server with OpenCode!");
     println!("Config file: {}", config_path.display());
@@ -1819,7 +1820,11 @@ fn main() {
                         data: None,
                     }),
                 };
-                let _ = writeln!(stdout, "{}", serde_json::to_string(&error_response).unwrap());
+                let _ = writeln!(
+                    stdout,
+                    "{}",
+                    serde_json::to_string(&error_response).unwrap()
+                );
                 let _ = stdout.flush();
                 continue;
             }


### PR DESCRIPTION
## Summary

- Run rustfmt on RustyRoad sources so the 1.0.27 release workflow formatting gate can pass.

## Validation

- **static/local:** Ran  only.
- **focused CI-like:** RustyRoad release run 28305871370 already showed clippy success and formatting failure before this fix.
- **not-run:** Did not compile Rust locally.