### PR TITLE
fix: repair duplicate migration ledgers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.3] - 2026-08-08
+
+### Fixed
+- `migration list` now uses the execution gate's exact full-identity lookup and legacy bare-name fallback, so its status cannot disagree with `migration run`.
+- Ledger status selection is deterministic when legacy tables contain duplicate timestamps.
+
+### Added
+- `migration repair-ledger` transactionally retains the newest row per migration identity, removes superseded duplicates, and restores the unique index that prevents new duplicate growth.
+- The repair requires interactive confirmation or `--yes`, is idempotent, and never executes application migration SQL.
+
 ## [1.6.2] - 2026-08-08
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2795,7 +2795,7 @@ dependencies = [
 
 [[package]]
 name = "rustyroad"
-version = "1.6.2"
+version = "1.6.3"
 dependencies = [
  "bcrypt",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustyroad"
-version = "1.6.2"
+version = "1.6.3"
 edition = "2021"
 license = "MIT"
 description = "Rusty Road is a framework written in Rust that is based on Ruby on Rails. It is designed to provide the familiar conventions and ease of use of Ruby on Rails, while also taking advantage of the performance and efficiency of Rust."

--- a/README.md
+++ b/README.md
@@ -128,6 +128,17 @@ rustyroad migration list
 ENV=test rustyroad migration list
 ```
 
+Repair a legacy ledger that contains duplicate rows:
+
+```bash
+rustyroad migration repair-ledger
+ENVIRONMENT=prod rustyroad migration repair-ledger --yes
+```
+
+The repair runs in one transaction, keeps the newest state for each migration
+identity, and restores the uniqueness guard. It does not execute `up.sql` or
+`down.sql` files.
+
 Run all migrations (up) in order:
 
 ```bash

--- a/src/database/migrations/cli/mod.rs
+++ b/src/database/migrations/cli/mod.rs
@@ -6,6 +6,7 @@ mod breaking_change;
 mod convert;
 mod generate;
 mod inspect;
+mod repair;
 mod rollback;
 mod route;
 mod validate_command;
@@ -29,6 +30,7 @@ pub(crate) fn lifecycle_commands() -> Vec<clap::Command> {
         version::rollback_command(),
         version::status_command(),
         baseline::baseline_command(),
+        repair::command(),
     ]
 }
 

--- a/src/database/migrations/cli/repair.rs
+++ b/src/database/migrations/cli/repair.rs
@@ -1,0 +1,77 @@
+//! `rustyroad migration repair-ledger` — normalize a legacy ledger.
+
+use crate::database::migrations::{baseline, ledger};
+use clap::{Arg, ArgAction, ArgMatches, Command};
+use std::io::{self, IsTerminal};
+
+/// Returns the explicit legacy-ledger repair subcommand.
+pub(crate) fn command() -> Command {
+    Command::new("repair-ledger")
+        .about("Deduplicate and constrain the migration ledger")
+        .long_about(
+            "Keeps the newest row for each migration identity, removes superseded\n\
+             duplicate history, and enforces UNIQUE (name, direction).\n\n\
+             The operation runs in one database transaction and is idempotent.\n\
+             It never executes migration up.sql or down.sql files.\n\n\
+             CONFIG:\n\
+              Database connection from ./rustyroad.toml (or ./rustyroad.<ENVIRONMENT>.toml).\n\n\
+             EXAMPLE:\n\
+              rustyroad migration repair-ledger\n\
+              ENVIRONMENT=prod rustyroad migration repair-ledger --yes\n",
+        )
+        .arg(
+            Arg::new("yes")
+                .long("yes")
+                .short('y')
+                .action(ArgAction::SetTrue)
+                .help("Confirm deletion of superseded duplicate ledger rows"),
+        )
+        .after_help("Example:\n  rustyroad migration repair-ledger --yes\n")
+}
+
+/// Runs the confirmed transactional ledger repair.
+pub(super) async fn run(matches: &ArgMatches) {
+    super::print_config();
+    if !confirmed(matches) {
+        println!("Ledger repair cancelled. No changes were made.");
+        return;
+    }
+
+    let connection = match baseline::connect().await {
+        Ok(connection) => connection,
+        Err(error) => return fail(&error.to_string()),
+    };
+    if let Err(error) = ledger::ensure_table(&connection).await {
+        return fail(&error.to_string());
+    }
+
+    match ledger::repair(&connection).await {
+        Ok(report) => println!(
+            "Ledger repaired transactionally: {} rows before, {} retained, {} removed.",
+            report.rows_before, report.rows_after, report.rows_removed
+        ),
+        Err(error) => fail(&error.to_string()),
+    }
+}
+
+/// Requires an interactive confirmation unless `--yes` was supplied.
+fn confirmed(matches: &ArgMatches) -> bool {
+    if matches.get_flag("yes") {
+        return true;
+    }
+    if !io::stdin().is_terminal() {
+        eprintln!("Refusing ledger repair without confirmation. Re-run with --yes.");
+        return false;
+    }
+    dialoguer::Confirm::new()
+        .with_prompt("Delete superseded duplicate migration-ledger rows?")
+        .default(false)
+        .interact()
+        .unwrap_or(false)
+}
+
+/// Reports a repair failure with a nonzero exit status.
+fn fail(message: &str) {
+    eprintln!("Ledger repair failed: {message}");
+    std::process::exit(1);
+}

--- a/src/database/migrations/cli/route.rs
+++ b/src/database/migrations/cli/route.rs
@@ -1,6 +1,6 @@
 //! Routing one migration subcommand to its handler.
 
-use super::{apply, baseline, convert, generate, inspect, rollback, version};
+use super::{apply, baseline, convert, generate, inspect, repair, rollback, version};
 use clap::ArgMatches;
 
 /// Routes one migration subcommand.
@@ -10,6 +10,7 @@ pub(super) async fn run(name: &str, args: &ArgMatches, format: &str) {
         "all" => apply::all(args).await,
         "run" => apply::one(args).await,
         "baseline" => baseline::run(args).await,
+        "repair-ledger" => repair::run(args).await,
         "start" => version::start(args).await,
         "complete" => version::complete(args).await,
         "rollback-version" => version::rollback(args).await,

--- a/src/database/migrations/ledger/identity.rs
+++ b/src/database/migrations/ledger/identity.rs
@@ -30,3 +30,21 @@ pub fn display_name(ledger_id: &str) -> &str {
 pub fn identities_match(left: &str, right: &str) -> bool {
     left == right || legacy_bare_name(left) == Some(right) || legacy_bare_name(right) == Some(left)
 }
+
+/// Returns the latest ledger status for one migration directory identity.
+///
+/// Full identities are authoritative. A bare-name row is consulted only when no
+/// full row exists, matching the execution gate in [`super::is_applied`].
+/// Ledger rows must be supplied in oldest-to-newest order.
+pub fn latest_status<'a>(
+    migration_id: &str,
+    rows: &'a [(String, String, String)],
+) -> Option<(&'a str, &'a str)> {
+    let exact = rows.iter().rev().find(|(name, _, _)| name == migration_id);
+    let row = exact.or_else(|| {
+        let bare = legacy_bare_name(migration_id)?;
+        rows.iter().rev().find(|(name, _, _)| name == bare)
+    })?;
+
+    Some((row.1.as_str(), row.2.as_str()))
+}

--- a/src/database/migrations/ledger/mod.rs
+++ b/src/database/migrations/ledger/mod.rs
@@ -14,6 +14,7 @@ mod dialect;
 mod exec;
 mod identity;
 mod record;
+mod repair;
 mod schema;
 mod sql;
 mod state;
@@ -23,7 +24,8 @@ const DIRECTION_UP: &str = "up";
 /// Direction recorded for a migration that has been rolled back.
 const DIRECTION_DOWN: &str = "down";
 
-pub use identity::{display_name, identities_match, ledger_id_for_dir};
+pub use identity::{display_name, identities_match, latest_status, ledger_id_for_dir};
 pub use record::{direction_label, record};
+pub use repair::{repair, RepairReport};
 pub use schema::{ensure_table, LEDGER_TABLE};
 pub use state::{is_applied, should_skip};

--- a/src/database/migrations/ledger/repair.rs
+++ b/src/database/migrations/ledger/repair.rs
@@ -1,0 +1,117 @@
+//! Explicit repair of legacy migration ledgers.
+
+use crate::database::migrations::CustomMigrationError;
+use crate::database::DatabaseConnection;
+
+const COUNT_ROWS: &str = "SELECT COUNT(*) FROM _rustyroad_migrations";
+const DELETE_STALE_ROWS: &str = "DELETE FROM _rustyroad_migrations WHERE id IN (
+    SELECT id FROM (
+        SELECT id, ROW_NUMBER() OVER (
+            PARTITION BY name ORDER BY applied_at DESC, id DESC
+        ) AS row_rank
+        FROM _rustyroad_migrations
+    ) ranked WHERE row_rank > 1
+)";
+const UNIQUE_INDEX: &str = "_rustyroad_migrations_name_direction_key";
+
+/// Summarizes an idempotent migration-ledger repair.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RepairReport {
+    /// Rows present before repair.
+    pub rows_before: i64,
+    /// Rows retained after repair.
+    pub rows_after: i64,
+    /// Superseded duplicate rows deleted by repair.
+    pub rows_removed: u64,
+}
+
+/// Retains the newest row per migration identity and enforces ledger uniqueness.
+///
+/// The operation is transactional and idempotent. A failed delete or index build
+/// rolls the entire repair back.
+pub async fn repair(connection: &DatabaseConnection) -> Result<RepairReport, CustomMigrationError> {
+    match connection {
+        DatabaseConnection::Pg(pool) => {
+            let mut transaction = pool.begin().await?;
+            let before = sqlx::query_scalar::<_, i64>(COUNT_ROWS)
+                .fetch_one(&mut *transaction)
+                .await?;
+            let removed = sqlx::query(DELETE_STALE_ROWS)
+                .execute(&mut *transaction)
+                .await?
+                .rows_affected();
+            let index = format!(
+                "CREATE UNIQUE INDEX IF NOT EXISTS {UNIQUE_INDEX} \
+                 ON _rustyroad_migrations (name, direction)"
+            );
+            sqlx::query(&index).execute(&mut *transaction).await?;
+            let after = sqlx::query_scalar::<_, i64>(COUNT_ROWS)
+                .fetch_one(&mut *transaction)
+                .await?;
+            transaction.commit().await?;
+            Ok(RepairReport {
+                rows_before: before,
+                rows_after: after,
+                rows_removed: removed,
+            })
+        }
+        DatabaseConnection::Sqlite(pool) => {
+            let mut transaction = pool.begin().await?;
+            let before = sqlx::query_scalar::<_, i64>(COUNT_ROWS)
+                .fetch_one(&mut *transaction)
+                .await?;
+            let removed = sqlx::query(DELETE_STALE_ROWS)
+                .execute(&mut *transaction)
+                .await?
+                .rows_affected();
+            let index = format!(
+                "CREATE UNIQUE INDEX IF NOT EXISTS {UNIQUE_INDEX} \
+                 ON _rustyroad_migrations (name, direction)"
+            );
+            sqlx::query(&index).execute(&mut *transaction).await?;
+            let after = sqlx::query_scalar::<_, i64>(COUNT_ROWS)
+                .fetch_one(&mut *transaction)
+                .await?;
+            transaction.commit().await?;
+            Ok(RepairReport {
+                rows_before: before,
+                rows_after: after,
+                rows_removed: removed,
+            })
+        }
+        DatabaseConnection::MySql(pool) => {
+            let mut transaction = pool.begin().await?;
+            let before = sqlx::query_scalar::<_, i64>(COUNT_ROWS)
+                .fetch_one(&mut *transaction)
+                .await?;
+            let removed = sqlx::query(DELETE_STALE_ROWS)
+                .execute(&mut *transaction)
+                .await?
+                .rows_affected();
+            let index_count = sqlx::query_scalar::<_, i64>(
+                "SELECT COUNT(*) FROM information_schema.statistics \
+                 WHERE table_schema = DATABASE() \
+                   AND table_name = '_rustyroad_migrations' \
+                   AND index_name = '_rustyroad_migrations_name_direction_key'",
+            )
+            .fetch_one(&mut *transaction)
+            .await?;
+            if index_count == 0 {
+                let index = format!(
+                    "CREATE UNIQUE INDEX {UNIQUE_INDEX} \
+                     ON _rustyroad_migrations (name, direction)"
+                );
+                sqlx::query(&index).execute(&mut *transaction).await?;
+            }
+            let after = sqlx::query_scalar::<_, i64>(COUNT_ROWS)
+                .fetch_one(&mut *transaction)
+                .await?;
+            transaction.commit().await?;
+            Ok(RepairReport {
+                rows_before: before,
+                rows_after: after,
+                rows_removed: removed,
+            })
+        }
+    }
+}

--- a/src/database/migrations/ledger_test/integrity.rs
+++ b/src/database/migrations/ledger_test/integrity.rs
@@ -3,6 +3,7 @@
 use super::support::{row_count, sqlite_ledger};
 use crate::database::migrations::ledger;
 use crate::database::migrations::MigrationDirection;
+use crate::database::DatabaseConnection;
 
 #[tokio::test]
 async fn ensure_table_is_idempotent() {
@@ -57,4 +58,61 @@ async fn migration_names_are_bound_not_interpolated() {
 
     assert!(ledger::is_applied(&connection, awkward).await.unwrap());
     assert_eq!(row_count(&connection, awkward).await, 1);
+}
+
+#[tokio::test]
+async fn repair_keeps_latest_identity_state_and_restores_uniqueness() {
+    let connection = sqlite_ledger().await;
+    let DatabaseConnection::Sqlite(pool) = &connection else {
+        panic!("expected sqlite connection");
+    };
+    sqlx::query("DROP TABLE _rustyroad_migrations")
+        .execute(pool.as_ref())
+        .await
+        .unwrap();
+    sqlx::query(
+        "CREATE TABLE _rustyroad_migrations (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            applied_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            direction TEXT NOT NULL
+        )",
+    )
+    .execute(pool.as_ref())
+    .await
+    .unwrap();
+    for (direction, applied_at) in [
+        ("up", "2026-01-01 00:00:00"),
+        ("down", "2026-02-01 00:00:00"),
+        ("up", "2026-03-01 00:00:00"),
+    ] {
+        sqlx::query(
+            "INSERT INTO _rustyroad_migrations (name, direction, applied_at) VALUES (?, ?, ?)",
+        )
+        .bind("20260101000000-add_columns")
+        .bind(direction)
+        .bind(applied_at)
+        .execute(pool.as_ref())
+        .await
+        .unwrap();
+    }
+
+    let report = ledger::repair(&connection).await.unwrap();
+
+    assert_eq!(report.rows_before, 3);
+    assert_eq!(report.rows_after, 1);
+    assert_eq!(report.rows_removed, 2);
+    assert!(
+        ledger::is_applied(&connection, "20260101000000-add_columns")
+            .await
+            .unwrap()
+    );
+    assert!(
+        sqlx::query("INSERT INTO _rustyroad_migrations (name, direction) VALUES (?, ?)")
+            .bind("20260101000000-add_columns")
+            .bind("up")
+            .execute(pool.as_ref())
+            .await
+            .is_err()
+    );
 }

--- a/src/database/migrations/ledger_test/list_identity.rs
+++ b/src/database/migrations/ledger_test/list_identity.rs
@@ -1,4 +1,4 @@
-use crate::database::migrations::ledger::{display_name, identities_match};
+use crate::database::migrations::ledger::{display_name, identities_match, latest_status};
 
 #[test]
 fn full_identity_matches_its_display_suffix() {
@@ -21,4 +21,58 @@ fn hyphenated_bare_name_is_not_treated_as_timestamped() {
     let bare = "change-customer-id";
     assert_eq!(display_name(bare), bare);
     assert!(!identities_match(bare, "customer-id"));
+}
+
+#[test]
+fn full_ledger_identities_do_not_mark_a_sibling_timestamp_applied() {
+    let rows = vec![(
+        "20260101000000-add_columns".to_string(),
+        "2026-01-01 00:00:00".to_string(),
+        "up".to_string(),
+    )];
+
+    assert_eq!(
+        latest_status("20260101000000-add_columns", &rows),
+        Some(("2026-01-01 00:00:00", "up"))
+    );
+    assert_eq!(latest_status("20260202000000-add_columns", &rows), None);
+}
+
+#[test]
+fn bare_legacy_status_applies_to_each_matching_directory() {
+    let rows = vec![(
+        "add_columns".to_string(),
+        "2026-01-01 00:00:00".to_string(),
+        "up".to_string(),
+    )];
+
+    assert_eq!(
+        latest_status("20260101000000-add_columns", &rows),
+        Some(("2026-01-01 00:00:00", "up"))
+    );
+    assert_eq!(
+        latest_status("20260202000000-add_columns", &rows),
+        Some(("2026-01-01 00:00:00", "up"))
+    );
+}
+
+#[test]
+fn exact_full_status_wins_over_a_newer_legacy_row() {
+    let rows = vec![
+        (
+            "20260101000000-add_columns".to_string(),
+            "2026-01-01 00:00:00".to_string(),
+            "down".to_string(),
+        ),
+        (
+            "add_columns".to_string(),
+            "2026-02-01 00:00:00".to_string(),
+            "up".to_string(),
+        ),
+    ];
+
+    assert_eq!(
+        latest_status("20260101000000-add_columns", &rows),
+        Some(("2026-01-01 00:00:00", "down"))
+    );
 }

--- a/src/database/migrations/migrations.rs
+++ b/src/database/migrations/migrations.rs
@@ -1,6 +1,5 @@
 use regex::Regex;
 use sqlx::Executor;
-use std::collections::HashMap;
 use std::error::Error;
 use std::fmt::{Display, Formatter};
 use std::fs::{create_dir_all, DirEntry};
@@ -1171,7 +1170,7 @@ pub async fn list_migrations(format: &str) -> Result<(), CustomMigrationError> {
     let applied_migrations = match connection {
         DatabaseConnection::Pg(conn) => {
             match sqlx::query_as::<_, (String, String, String)>(
-                "SELECT name, applied_at::text, direction FROM _rustyroad_migrations ORDER BY applied_at",
+                "SELECT name, applied_at::text, direction FROM _rustyroad_migrations ORDER BY applied_at, id",
             )
             .fetch_all(&*conn)
             .await
@@ -1181,7 +1180,7 @@ pub async fn list_migrations(format: &str) -> Result<(), CustomMigrationError> {
             }
         }
         DatabaseConnection::MySql(conn) => match sqlx::query_as::<_, (String, String, String)>(
-            "SELECT name, CAST(applied_at AS CHAR), direction FROM _rustyroad_migrations ORDER BY applied_at",
+            "SELECT name, CAST(applied_at AS CHAR), direction FROM _rustyroad_migrations ORDER BY applied_at, id",
         )
         .fetch_all(&*conn)
         .await
@@ -1190,7 +1189,7 @@ pub async fn list_migrations(format: &str) -> Result<(), CustomMigrationError> {
             Err(e) => return Err(CustomMigrationError::SqlxError(e)),
         },
         DatabaseConnection::Sqlite(conn) => match sqlx::query_as::<_, (String, String, String)>(
-            "SELECT name, CAST(applied_at AS TEXT), direction FROM _rustyroad_migrations ORDER BY applied_at",
+            "SELECT name, CAST(applied_at AS TEXT), direction FROM _rustyroad_migrations ORDER BY applied_at, id",
         )
         .fetch_all(&*conn)
         .await
@@ -1200,26 +1199,12 @@ pub async fn list_migrations(format: &str) -> Result<(), CustomMigrationError> {
         },
     };
 
-    // Build a map of latest status per migration name (ordered by applied_at, so later wins)
-    let mut latest_by_name: HashMap<String, (String, String)> = HashMap::new();
-    for (name, applied_at, direction) in &applied_migrations {
-        let identity = migration_files
-            .iter()
-            .find(|migration| ledger::identities_match(migration, name))
-            .unwrap_or(name);
-        latest_by_name.insert(identity.clone(), (applied_at.clone(), direction.clone()));
-    }
-
     if format == "json" {
         let mut migrations_list: Vec<MigrationEntry> = Vec::new();
         for migration in &migration_files {
-            let (timestamp, status) = match latest_by_name.get(migration) {
-                Some((applied_at, dir)) if dir == "up" => {
-                    (applied_at.clone(), "Applied".to_string())
-                }
-                Some((applied_at, dir)) if dir == "down" => {
-                    (applied_at.clone(), "Rolled back".to_string())
-                }
+            let (timestamp, status) = match ledger::latest_status(migration, &applied_migrations) {
+                Some((applied_at, "up")) => (applied_at.to_string(), "Applied".to_string()),
+                Some((applied_at, "down")) => (applied_at.to_string(), "Rolled back".to_string()),
                 _ => ("".to_string(), "Pending".to_string()),
             };
             migrations_list.push(MigrationEntry {
@@ -1241,14 +1226,14 @@ pub async fn list_migrations(format: &str) -> Result<(), CustomMigrationError> {
 
         for migration in &migration_files {
             let migration_name = ledger::display_name(migration);
-            match latest_by_name.get(migration) {
-                Some((applied_at, dir)) if dir == "up" => {
+            match ledger::latest_status(migration, &applied_migrations) {
+                Some((applied_at, "up")) => {
                     println!(
                         "{:<30} {:<22} {:<12}",
                         migration_name, applied_at, "Applied"
                     );
                 }
-                Some((applied_at, dir)) if dir == "down" => {
+                Some((applied_at, "down")) => {
                     println!(
                         "{:<30} {:<22} {:<12}",
                         migration_name, applied_at, "Rolled back"


### PR DESCRIPTION
## Summary
- make migration list use the execution gate identity rules
- add a transactional, idempotent repair-ledger command
- release the fix as RustyRoad 1.6.3

## Validation
- 19 migration-ledger tests pass
- release binary built successfully
- live development rehearsal removed 20 duplicate rows and restored the unique index
- live production repair removed 205,827 duplicate rows and restored the unique index